### PR TITLE
Update IDE interpreters

### DIFF
--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -98,6 +98,9 @@ ENV NODE_VERSION 12.8.1
 RUN PATH=${HOME}/.asdf/bin:${PATH} ${HOME}/.asdf/plugins/nodejs/bin/import-release-team-keyring \
   && PATH=${HOME}/.asdf/bin:${PATH} ${HOME}/.asdf/bin/asdf install nodejs ${NODE_VERSION} \
   && ${HOME}/.asdf/bin/asdf global nodejs ${NODE_VERSION}
+ENV YARN_VERSION 1.17.3
+RUN ${HOME}/.asdf/bin/asdf install yarn ${YARN_VERSION} \
+  && ${HOME}/.asdf/bin/asdf global yarn ${YARN_VERSION}
 
 # fetch/install code server
 ENV CODE_VERSION 1.1156-vsc1.33.1

--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -58,8 +58,8 @@ ENV PATH /usr/local/bin:$PATH
 
 # fetch/install asdf
 RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.7.4 \
-  && echo -e '\n. ${HOME}/.asdf/asdf.sh' >> ~/.bashrc \
-  && echo -e '\n. ${HOME}/.asdf/completions/asdf.bash' >> ~/.bashrc \
+  && echo '\n. ${HOME}/.asdf/asdf.sh' >> ~/.bashrc \
+  && echo '\n. ${HOME}/.asdf/completions/asdf.bash' >> ~/.bashrc \
   && ${HOME}/.asdf/bin/asdf plugin-add python \
   && ${HOME}/.asdf/bin/asdf plugin-add erlang \
   && ${HOME}/.asdf/bin/asdf plugin-add rebar \

--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -57,7 +57,8 @@ ENV LANG en_US.UTF-8
 ENV PATH /usr/local/bin:$PATH
 
 # fetch/install asdf
-RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.7.4 \
+ENV ASDF_VERSION v0.7.4
+RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch ${ASDF_VERSION} \
   && echo '\n. ${HOME}/.asdf/asdf.sh' >> ~/.bashrc \
   && echo '\n. ${HOME}/.asdf/completions/asdf.bash' >> ~/.bashrc \
   && ${HOME}/.asdf/bin/asdf plugin-add python \
@@ -69,29 +70,34 @@ RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.7.4 \
   && ${HOME}/.asdf/bin/asdf plugin-add golang
 
 # fetch/install python
-RUN ${HOME}/.asdf/bin/asdf install python 3.7.4 \
-  && ${HOME}/.asdf/bin/asdf global python 3.7.4
+ENV PYTHON_VERSION 3.7.4
+RUN ${HOME}/.asdf/bin/asdf install python ${PYTHON_VERSION} \
+  && ${HOME}/.asdf/bin/asdf global python ${PYTHON_VERSION}
 
 # fetch/install golang
+ENV GO_VERSION 1.12.9
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
-RUN ${HOME}/.asdf/bin/asdf install golang 1.12.9 \
-  && ${HOME}/.asdf/bin/asdf global golang 1.12.9 \
+RUN ${HOME}/.asdf/bin/asdf install golang ${GO_VERSION} \
+  && ${HOME}/.asdf/bin/asdf global golang ${GO_VERSION} \
   && mkdir -p "${GOPATH}/src" "${GOPATH}/bin" \
   && chmod -R 777 "${GOPATH}"
 
 # fetch/install erlang
-RUN ${HOME}/.asdf/bin/asdf install erlang 22.0.7 \
-  && ${HOME}/.asdf/bin/asdf global erlang 22.0.7
+ENV ERLANG_VERSION 22.0.7
+RUN ${HOME}/.asdf/bin/asdf install erlang ${ERLANG_VERSION} \
+  && ${HOME}/.asdf/bin/asdf global erlang ${ERLANG_VERSION}
 
 # fetch/install elixir
-RUN ${HOME}/.asdf/bin/asdf install elixir 1.9.1-otp-22 \
-  && ${HOME}/.asdf/bin/asdf global elixir 1.9.1-otp-22
+ENV ELIXIR_VERSION 1.9.1-otp-22
+RUN ${HOME}/.asdf/bin/asdf install elixir ${ELIXIR_VERSION} \
+  && ${HOME}/.asdf/bin/asdf global elixir ${ELIXIR_VERSION}
 
 # fetch/install node/yarn
+ENV NODE_VERSION 12.8.1
 RUN PATH=${HOME}/.asdf/bin:${PATH} ${HOME}/.asdf/plugins/nodejs/bin/import-release-team-keyring \
-  && PATH=${HOME}/.asdf/bin:${PATH} ${HOME}/.asdf/bin/asdf install nodejs 12.8.1 \
-  && ${HOME}/.asdf/bin/asdf global nodejs 12.8.1
+  && PATH=${HOME}/.asdf/bin:${PATH} ${HOME}/.asdf/bin/asdf install nodejs ${NODE_VERSION} \
+  && ${HOME}/.asdf/bin/asdf global nodejs ${NODE_VERSION}
 
 # fetch/install code server
 ENV CODE_VERSION 1.1156-vsc1.33.1

--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -8,245 +8,94 @@ RUN groupadd --gid 1000 coder \
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-    git \
-    locales \
-    net-tools \
-    openssl \
-    curl \
-    wget \
+    autoconf \
+    automake \
+    build-essential \
     ca-certificates \
-    gpg \
-    gpg-agent \
+    curl \
     dirmngr \
-    libssl-dev \
-    libffi-dev \
-    tk-dev \
-    uuid-dev \
     g++ \
     gcc \
+    git \
+    gpg \
+    gpg-agent \
+    libbz2-dev \
     libc6-dev \
-    make \
-    pkg-config \
-    libodbc1 \
-    libsctp1 \
-    libwxgtk3.0 \
+    libffi-dev \
+    liblzma-dev \
+    libncurses-dev \
     libncurses5-dev \
-    unixodbc-dev \
+    libncursesw5-dev \
+    libodbc1 \
+    libreadline-dev \
     libsctp-dev \
+    libsctp1 \
+    libsqlite3-dev \
+    libssl-dev \
+    libtool \
+    libwxgtk3.0 \
     libwxgtk3.0-dev \
+    libxslt-dev \
+    libyaml-dev \
+    llvm \
+    locales \
+    make \
+    net-tools \
+    openssl \
+    pkg-config \
+    python-openssl \
+    tk-dev \
+    unixodbc-dev \
+    unzip \
+    uuid-dev \
+    wget \
+    xz-utils \
+    zlib1g-dev \
   && rm -rf /var/lib/apt/lists/* \
   && locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV PATH /usr/local/bin:$PATH
 
+# fetch/install asdf
+RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.7.4 \
+  && echo -e '\n. ${HOME}/.asdf/asdf.sh' >> ~/.bashrc \
+  && echo -e '\n. ${HOME}/.asdf/completions/asdf.bash' >> ~/.bashrc \
+  && ${HOME}/.asdf/bin/asdf plugin-add python \
+  && ${HOME}/.asdf/bin/asdf plugin-add erlang \
+  && ${HOME}/.asdf/bin/asdf plugin-add rebar \
+  && ${HOME}/.asdf/bin/asdf plugin-add elixir \
+  && ${HOME}/.asdf/bin/asdf plugin-add nodejs \
+  && ${HOME}/.asdf/bin/asdf plugin-add yarn \
+  && ${HOME}/.asdf/bin/asdf plugin-add golang
+
 # fetch/install python
-ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-ENV PYTHON_VERSION 3.7.2
-RUN set -ex \
-  \
-  && wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
-  && wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
-  && gpg --batch --verify python.tar.xz.asc python.tar.xz \
-  && { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
-  && rm -rf "$GNUPGHOME" python.tar.xz.asc \
-  && mkdir -p /usr/src/python \
-  && tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
-  && rm python.tar.xz \
-  \
-  && cd /usr/src/python \
-  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-  && ./configure \
-    --build="$gnuArch" \
-    --enable-loadable-sqlite-extensions \
-    --enable-shared \
-    --with-system-expat \
-    --with-system-ffi \
-    --without-ensurepip \
-  && make -j "$(nproc)" \
-  && make install \
-  && ldconfig \
-  \
-  && find /usr/local -depth \
-    \( \
-      \( -type d -a \( -name test -o -name tests \) \) \
-      -o \
-      \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-    \) -exec rm -rf '{}' + \
-  && rm -rf /usr/src/python \
-  \
-  && python3 --version
-
-# make some useful symlinks that are expected to exist
-RUN cd /usr/local/bin \
-  && ln -s idle3 idle \
-  && ln -s pydoc3 pydoc \
-  && ln -s python3 python \
-  && ln -s python3-config python-config
-
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 19.0.3
-RUN set -ex; \
-  \
-  wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
-  \
-  python get-pip.py \
-    --disable-pip-version-check \
-    --no-cache-dir \
-    "pip==$PYTHON_PIP_VERSION" \
-    ; \
-  pip --version; \
-  \
-  find /usr/local -depth \
-    \( \
-      \( -type d -a \( -name test -o -name tests \) \) \
-      -o \
-      \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
-    \) -exec rm -rf '{}' +; \
-  rm -f get-pip.py
+RUN ${HOME}/.asdf/bin/asdf install python 3.7.4 \
+  && ${HOME}/.asdf/bin/asdf global python 3.7.4
 
 # fetch/install golang
-ENV GOLANG_VERSION 1.12
-ENV GOLANG_ARCH linux-amd64
-ENV GOLANG_SHA256 750a07fef8579ae4839458701f4df690e0b20b8bcce33b437e4df89c451b6f13
-
-RUN set -eux; \
-  url="https://golang.org/dl/go${GOLANG_VERSION}.${GOLANG_ARCH}.tar.gz"; \
-  wget -O go.tgz "$url"; \
-  echo "${GOLANG_SHA256} *go.tgz" | sha256sum -c -; \
-  tar -C /usr/local -xzf go.tgz; \
-  rm go.tgz; \
-  export PATH="/usr/local/go/bin:$PATH"; \
-  go version
-
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+RUN ${HOME}/.asdf/bin/asdf install golang 1.12.9 \
+  && ${HOME}/.asdf/bin/asdf global golang 1.12.9
+# ENV GOPATH /go
+# ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+# RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
 # fetch/install erlang
-ENV OTP_VERSION="21.3"
-
-# We'll install the build dependencies for erlang-odbc along with the erlang
-# build process:
-  RUN set -xe \
-  && OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-  && OTP_DOWNLOAD_SHA256="64a6eea6c1dc2353ad80e29ef57f6ec4192c91478ac2b854d0417b6b2bf4d9bf" \
-  && runtimeDeps='libodbc1 \
-    libsctp1 \
-    libwxgtk3.0' \
-  && buildDeps='unixodbc-dev \
-    libsctp-dev \
-    libwxgtk3.0-dev' \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends $runtimeDeps \
-  && apt-get install -y --no-install-recommends $buildDeps \
-  && curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
-  && echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
-  && export ERL_TOP="/usr/src/otp_src_${OTP_VERSION%%@*}" \
-  && mkdir -vp $ERL_TOP \
-  && tar -xzf otp-src.tar.gz -C $ERL_TOP --strip-components=1 \
-  && rm otp-src.tar.gz \
-  && ( cd $ERL_TOP \
-  && ./otp_build autoconf \
-  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-  && ./configure --build="$gnuArch" \
-  && make -j$(nproc) \
-  && make install ) \
-  && find /usr/local -name examples | xargs rm -rf \
-  && rm -rf $ERL_TOP
+RUN ${HOME}/.asdf/bin/asdf install erlang 22.0.7 \
+  && ${HOME}/.asdf/bin/asdf global erlang 22.0.7
 
 # extra useful tools here: rebar & rebar3
-ENV REBAR_VERSION="2.6.4"
-RUN set -xe \
-  && REBAR_DOWNLOAD_URL="https://github.com/rebar/rebar/archive/${REBAR_VERSION}.tar.gz" \
-  && REBAR_DOWNLOAD_SHA256="577246bafa2eb2b2c3f1d0c157408650446884555bf87901508ce71d5cc0bd07" \
-  && mkdir -p /usr/src/rebar-src \
-  && curl -fSL -o rebar-src.tar.gz "$REBAR_DOWNLOAD_URL" \
-  && echo "$REBAR_DOWNLOAD_SHA256 rebar-src.tar.gz" | sha256sum -c - \
-  && tar -xzf rebar-src.tar.gz -C /usr/src/rebar-src --strip-components=1 \
-  && rm rebar-src.tar.gz \
-  && cd /usr/src/rebar-src \
-  && ./bootstrap \
-  && install -v ./rebar /usr/local/bin/ \
-  && rm -rf /usr/src/rebar-src
-
-ENV REBAR3_VERSION="3.9.0"
-RUN set -xe \
-  && REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-  && REBAR3_DOWNLOAD_SHA256="9ea73ce4e60ad4b3108641eae73b4098fadb510142e672ad8e3a793f57e9f992" \
-  && mkdir -p /usr/src/rebar3-src \
-  && curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
-  && echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \
-  && tar -xzf rebar3-src.tar.gz -C /usr/src/rebar3-src --strip-components=1 \
-  && rm rebar3-src.tar.gz \
-  && cd /usr/src/rebar3-src \
-  && HOME=$PWD ./bootstrap \
-  && install -v ./rebar3 /usr/local/bin/ \
-  && rm -rf /usr/src/rebar3-src
+# RUN ${HOME}/.asdf/bin/asdf install rebar 2.6.4 \
+#   && ${HOME}/.asdf/bin/asdf install rebar 3.11.0 \
+#   && ${HOME}/.asdf/bin/asdf global rebar 3.11.0
 
 # fetch/install elixir
-ENV ELIXIR_VERSION="v1.8.1"
-
-RUN set -xe \
-  && ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-  && ELIXIR_DOWNLOAD_SHA256="de8c636ea999392496ccd9a204ccccbc8cb7f417d948fd12692cda2bd02d9822" \
-  && curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
-  && echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
-  && mkdir -p /usr/local/src/elixir \
-  && tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
-  && rm elixir-src.tar.gz \
-  && cd /usr/local/src/elixir \
-  && make install clean
+RUN ${HOME}/.asdf/bin/asdf install elixir 1.9.1-otp-22 \
+  && ${HOME}/.asdf/bin/asdf global elixir 1.9.1-otp-22
 
 # fetch/install node/yarn
-ENV NODE_VERSION 8.15.1
-
-RUN ARCH='x64' \
-  # gpg keys listed at https://github.com/nodejs/node#release-keys
-  && set -ex \
-  && for key in \
-      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-      FD3A5288F042B6850C66B31F09FE44734EB7990E \
-      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-      B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-      77984A986EBC2AA786BC0F66B01FBB92821C587A \
-      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-      4ED778F539E3634C779C87C6D7062848A1AB005C \
-      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
-      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
-    ; do \
-      gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-      gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-      gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-    done \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
-
-ENV YARN_VERSION 1.12.3
-RUN set -ex \
-  && for key in \
-      6A010C5166006599AA17F08146C2130DFD2497F5 \
-    ; do \
-      gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-      gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-      gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-    done \
-  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
-  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && mkdir -p /opt \
-  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+RUN PATH=${HOME}/.asdf/bin:${PATH} ${HOME}/.asdf/plugins/nodejs/bin/import-release-team-keyring \
+  && PATH=${HOME}/.asdf/bin:${PATH} ${HOME}/.asdf/bin/asdf install nodejs 12.8.1 \
+  && ${HOME}/.asdf/bin/asdf global nodejs 12.8.1
 
 # fetch/install code server
 ENV CODE_VERSION 1.1156-vsc1.33.1
@@ -258,18 +107,6 @@ RUN curl -L ${CODE_URL} | tar xz \
   && cp ${CODE_PATH}/code-server /usr/local/bin \
   && cd / \
   && rm -rf /opt/${CODE_PATH}
-
-# install code server extensions
-# RUN code-server \
-#     --install-extension peterjausovec.vscode-docker \
-#     --install-extension editorconfig.editorconfig \
-#     --install-extension eamodio.gitlens \
-#     --install-extension ms-vscode.go \
-#     --install-extension prisma.vscode-graphql \
-#     --install-extension ms-python.python \
-#     --install-extension octref.vetur \
-#     --install-extension vscodevim.vim \
-#     --install-extension mjmcloug.vscode-elixir
 
 WORKDIR /root/project
 EXPOSE 8443

--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -73,20 +73,16 @@ RUN ${HOME}/.asdf/bin/asdf install python 3.7.4 \
   && ${HOME}/.asdf/bin/asdf global python 3.7.4
 
 # fetch/install golang
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$PATH
 RUN ${HOME}/.asdf/bin/asdf install golang 1.12.9 \
-  && ${HOME}/.asdf/bin/asdf global golang 1.12.9
-# ENV GOPATH /go
-# ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-# RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+  && ${HOME}/.asdf/bin/asdf global golang 1.12.9 \
+  && mkdir -p "${GOPATH}/src" "${GOPATH}/bin" \
+  && chmod -R 777 "${GOPATH}"
 
 # fetch/install erlang
 RUN ${HOME}/.asdf/bin/asdf install erlang 22.0.7 \
   && ${HOME}/.asdf/bin/asdf global erlang 22.0.7
-
-# extra useful tools here: rebar & rebar3
-# RUN ${HOME}/.asdf/bin/asdf install rebar 2.6.4 \
-#   && ${HOME}/.asdf/bin/asdf install rebar 3.11.0 \
-#   && ${HOME}/.asdf/bin/asdf global rebar 3.11.0
 
 # fetch/install elixir
 RUN ${HOME}/.asdf/bin/asdf install elixir 1.9.1-otp-22 \

--- a/ide/README.md
+++ b/ide/README.md
@@ -2,19 +2,21 @@
 
 Run [`code-server`][0] with support to:
 
-1. [python (3.7.2)][1]
-2. [golang (1.12)][2]
-3. [erlang/otp (21.3)][3]
-4. [elixir (1.8.1)][4]
-5. [node (8.15.1)][5]
+1. [asdf (0.7.4)][1]
+2. [python (3.7.4)][2]
+3. [golang (1.12.9)][3]
+4. [erlang/otp (22.0.7)][4]
+5. [elixir (1.9.1)][5]
+6. [node (12.8.1)][6]
 
 ## Run the server
 
 Invoke `docker-compose up -d` and this will start the server.
 
 [0]: https://github.com/codercom/code-server
-[1]: https://github.com/docker-library/python/blob/ce69fc6369feb8ec757b019035ddad7bac20562c/3.7/stretch/Dockerfile
-[2]: https://github.com/docker-library/golang/blob/fd272b2b72db82a0bd516ce3d09bba624651516c/1.12/stretch/Dockerfile
-[3]: https://github.com/erlang/docker-erlang-otp/blob/81dc84940c670b01c8b5c5622b02500f4f77a4b9/21/Dockerfile
-[4]: https://github.com/c0b/docker-elixir/blob/5570afaa6de095a86e98457e1ad1351f92ccfe26/1.8/Dockerfile
-[5]: https://github.com/nodejs/docker-node/blob/de76fb48b532d6be012098dc3538bd15329a27d0/8/jessie/Dockerfile
+[1]: https://asdf-vm.com/#/
+[2]: https://github.com/danhper/asdf-python
+[3]: https://github.com/kennyp/asdf-golang
+[4]: https://github.com/asdf-vm/asdf-erlang
+[5]: https://github.com/asdf-vm/asdf-elixir
+[6]: https://github.com/asdf-vm/asdf-nodejs


### PR DESCRIPTION
Use `asdf` to handle all IDE versions and upgrade them to latest versions.