### PR TITLE
Misc updates in ansible playbooks

### DIFF
--- a/provision/ansible/playbooks/asdf.yml
+++ b/provision/ansible/playbooks/asdf.yml
@@ -2,21 +2,14 @@
 - hosts: dev
   vars:
     version:
-      erlang: '22.0.7'
-      elixir: '1.9.1-otp-22'
-      golang: '1.13'
-      java: 'adopt-openjdk-13+33_openj9-0.16.0'
-      kotlin: '1.3.50'
-      nodejs: '12.10.0'
-      yarn: '1.18.0'
-  tasks:
-    # NOTE (jpd): list all java versions depends on jq
-    - name: install jq
-      become: yes
-      apt:
-        name: jq
-        state: present
-        update_cache: yes
+      erlang: '22.3.3'
+      elixir: '1.10.3-otp-22'
+      golang: '1.14.2'
+      java: 'adopt-openjdk-14.0.1+7_openj9-0.20.0'
+      kotlin: '1.3.72'
+      nodejs: '14.2.0'
+      yarn: '1.22.4'
+  # NOTE (jpd): install jq before installing asdf
   roles:
     - role: cimon-io.asdf
       asdf_version: 'v0.7.4'

--- a/provision/ansible/playbooks/direnv.yml
+++ b/provision/ansible/playbooks/direnv.yml
@@ -3,7 +3,7 @@
   become: yes
   vars:
     direnv:
-      bin_url: 'https://github.com/direnv/direnv/releases/download/v2.19.2/direnv.linux-amd64'
-      bin_sha256: c85f8d0f48bbeffb4671b4e231637ce0b2bded6a5cb65cf42eba0d3e18ecf607
+      bin_url: 'https://github.com/direnv/direnv/releases/download/v2.21.2/direnv.linux-amd64'
+      bin_sha256: 6b61c3f4ff96d99344906d80a570dc8c0bd479de82b18bf9d9c802ce61612b8a
   roles:
     - role: laggyluke.direnv

--- a/provision/ansible/playbooks/jq.yml
+++ b/provision/ansible/playbooks/jq.yml
@@ -1,0 +1,10 @@
+---
+- hosts: dev
+  tasks:
+    # NOTE (jpd): list all java versions in asdf depends on jq
+    - name: install jq
+      become: yes
+      apt:
+        name: jq
+        state: present
+        update_cache: yes

--- a/provision/ansible/playbooks/tmux.yml
+++ b/provision/ansible/playbooks/tmux.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: dev
   vars:
+    pip_package: python3-pip
     pip_install_packages:
       - name: tmuxp
   tasks:

--- a/provision/ansible/requirements.yml
+++ b/provision/ansible/requirements.yml
@@ -1,13 +1,13 @@
 ---
 - src: geerlingguy.docker
-  version: 2.5.2
+  version: 2.7.0
 - src: geerlingguy.pip
   version: 1.3.0
 - src: dotstrap.neovim
 - src: avanov.pyenv
   version: 1.1.0
 - src: viasite-ansible.zsh
-  version: v3.2.3
+  version: v3.2.7
 - src: laggyluke.direnv
   version: v2.6.0
 - src: cimon-io.asdf


### PR DESCRIPTION
Some updates in ansible provisioner:

1. Update `direnv` to version 2.21.2
1. Update `asdf` tools:
    1. `erlang` to version 22.3.3
    1. `elixir` to version 1.10.3-otp-22
    1. `golang` to version 1.14.2
    1. `java` to version adopt-openjdk-14.0.1+7_openj9-0.20.0
    1. `kotlin` to version 1.3.72
    1. `nodejs` to version 14.2.0
    1. `yarn` to version 1.22.4
1. Move `jq` to own playbook
1. Use `python3` to install `tmuxp`
1. Update requirements from ansible-galaxy