### PR TITLE
Update interpreters and cli infra-as-code

### DIFF
--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -95,7 +95,7 @@ RUN git clone https://github.com/asdf-vm/asdf.git ${ASDF_HOME_DIR} --branch ${AS
   && echo '\n. ${ASDF_HOME_DIR}/completions/asdf.bash' >> ${HOME}/.zshrc.ext
 
 # fetch/install python
-ENV PYTHON_VERSION 3.9.0
+ENV PYTHON_VERSION 3.9.1
 RUN asdf plugin-add python \
   && asdf install python ${PYTHON_VERSION} \
   && asdf global python ${PYTHON_VERSION} \
@@ -103,7 +103,7 @@ RUN asdf plugin-add python \
   && ${ASDF_DATA_DIR}/installs/python/${PYTHON_VERSION}/bin/pip install pynvim
 
 # fetch/install golang
-ENV GO_VERSION 1.15.2
+ENV GO_VERSION 1.15.8
 ENV GOPATH ${HOME}/.config/go
 ENV PATH ${GOPATH}/bin:/usr/local/bin:${PATH}
 RUN asdf plugin-add golang \
@@ -113,32 +113,32 @@ RUN asdf plugin-add golang \
   && chmod -R 777 "${GOPATH}"
 
 # fetch/install java
-ENV JAVA_VERSION openjdk-15
+ENV JAVA_VERSION openjdk-16
 RUN asdf plugin-add java \
   && asdf install java ${JAVA_VERSION} \
   && asdf global java ${JAVA_VERSION} \
   && echo '\n. ${ASDF_DATA_DIR}/plugins/java/set-java-home.bash' >> ${HOME}/.zshrc.ext
 
 # fetch/install kotlin
-ENV KOTLIN_VERSION 1.4.10
+ENV KOTLIN_VERSION 1.4.30
 RUN asdf plugin-add kotlin \
   && asdf install kotlin ${KOTLIN_VERSION} \
   && asdf global kotlin ${KOTLIN_VERSION}
 
 # fetch/install erlang
-ENV ERLANG_VERSION 23.1.1
+ENV ERLANG_VERSION 23.2.4
 RUN asdf plugin-add erlang \
   && asdf install erlang ${ERLANG_VERSION} \
   && asdf global erlang ${ERLANG_VERSION}
 
 # fetch/install elixir
-ENV ELIXIR_VERSION 1.11.0-otp-23
+ENV ELIXIR_VERSION 1.11.3-otp-23
 RUN asdf plugin-add elixir \
   && asdf install elixir ${ELIXIR_VERSION} \
   && asdf global elixir ${ELIXIR_VERSION}
 
 # fetch/install node/yarn
-ENV NODE_VERSION 14.13.1
+ENV NODE_VERSION 15.8.0
 RUN asdf plugin-add nodejs \
   && ${ASDF_DATA_DIR}/plugins/nodejs/bin/import-release-team-keyring \
   && asdf install nodejs ${NODE_VERSION} \
@@ -200,7 +200,7 @@ RUN curl -LO ${GRPC_URL} \
   && rm ${GRPC_FILE}
 
 # fetch/install code server
-ENV CODE_VERSION 3.8.0
+ENV CODE_VERSION 3.9.0
 ENV CODE_RELEASE v${CODE_VERSION}
 ENV CODE_PATH code-server-${CODE_VERSION}-linux-amd64
 ENV CODE_FILE ${CODE_PATH}.tar.gz

--- a/ide/config/zsh/zshrc
+++ b/ide/config/zsh/zshrc
@@ -64,6 +64,7 @@ antibody bundle zsh-users/zsh-syntax-highlighting
 
 # user configuration {{{
 [[ -r "${HOME}/.zshrc.local" ]] && source ${HOME}/.zshrc.local
+[[ -r "${HOME}/.zshrc.ext" ]] && source ${HOME}/.zshrc.ext
 # }}}
 
 

--- a/ide/docker-compose.yml
+++ b/ide/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.7'
 services:
   coder:
-    image: 'joaodubas/code-server:3.8.0-zsh'
+    image: 'joaodubas/code-server:3.9.0-zsh'
     build:
       context: .
     init: true

--- a/provision/Dockerfile
+++ b/provision/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.13.0
+FROM hashicorp/terraform:0.14.4
 
 # NOTE (jpd): ansible install based in willian yeh install
 # https://github.com/William-Yeh/docker-ansible/blob/e1cb5d4aec1da7286717bdbe08ce891f53154a47/alpine3/Dockerfile
@@ -7,15 +7,17 @@ ENV DM_VERSION=v0.16.2
 ENV DM_RELEASE=docker-machine-Linux-x86_64
 ENV DM_BASE_URL=https://github.com/docker/machine/releases/download/${DM_VERSION}
 ENV DM_URL=${DM_BASE_URL}/${DM_RELEASE}
-ENV DC_VERSION=19.03.12
+ENV DC_VERSION=20.10.2
 ENV DC_URL=https://download.docker.com/linux/static/stable/x86_64/docker-${DC_VERSION}.tgz
 
-RUN echo "install docker-machine ... " \
+RUN echo "install system deps " \
     && apk --update add curl \
+    && echo "install docker ..." \
     && mkdir -p /tmp/download \
     && curl -L ${DC_URL} | tar -xz -C /tmp/download \
     && mv /tmp/download/docker/* /usr/local/bin \
     && rm -rf /tmp/download \
+    && echo "install docker-machine ..." \
     && curl -L ${DM_URL} -o /usr/local/bin/docker-machine \
     && chmod 755 /usr/local/bin/docker-machine \
     && echo "install ansible ..." \
@@ -28,7 +30,7 @@ RUN echo "install docker-machine ... " \
         openssl-dev \
         build-base \
     && pip3 install --upgrade pip cffi \
-    && pip3 install --upgrade ansible==2.9.12 \
+    && pip3 install --upgrade ansible==2.10.4 \
     && pip3 install --upgrade pycrypt pywinrm \
     && apk --update add sshpass openssh-client rsync \
     && mkdir -p /etc/ansible \

--- a/provision/ansible/playbooks/asdf.yml
+++ b/provision/ansible/playbooks/asdf.yml
@@ -2,17 +2,17 @@
 - hosts: dev
   vars:
     version:
-      erlang: '22.3.3'
-      elixir: '1.10.3-otp-22'
-      golang: '1.14.2'
-      java: 'adopt-openjdk-14.0.1+7_openj9-0.20.0'
-      kotlin: '1.3.72'
-      nodejs: '14.2.0'
-      yarn: '1.22.4'
+      erlang: '23.2.4'
+      elixir: '1.11.3-otp-23'
+      golang: '1.15.8'
+      java: 'openjdk-16'
+      kotlin: '1.4.30'
+      nodejs: '15.8.0'
+      yarn: '1.22.10'
   # NOTE (jpd): install jq before installing asdf
   roles:
     - role: cimon-io.asdf
-      asdf_version: 'v0.7.8'
+      asdf_version: 'v0.8.0'
       asdf_user: '{{ ansible_env.USER }}'
       asdf_user_home: '{{ ansible_env.HOME }}'
       asdf_plugins:

--- a/provision/docker-compose.yml
+++ b/provision/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.7'
 services:
   ops:
-    image: 'joaodubas/ops-tools:0.0.10'
+    image: 'joaodubas/ops-tools:0.0.11'
     build:
       context: .
     init: true

--- a/provision/terraform/versions.tf
+++ b/provision/terraform/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source = "terraform-providers/digitalocean"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
1. python 3.9.1
2. golang 1.15.8
3. java openjdk-16
4. kotlin 1.4.30
5. erlang 23.2.4
6. elixir 1.11.3
7. nodejs 15.8.0
8. yarn 1.22.10
9. docker 20.10.2
10. terraform 0.14.4
11. ansible 2.10.4
