### PR TITLE
Update provision tools

### DIFF
--- a/provision/Dockerfile
+++ b/provision/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.14.6
+FROM hashicorp/terraform:1.0.0
 
 # NOTE (jpd): ansible install based in willian yeh install
 # https://github.com/William-Yeh/docker-ansible/blob/e1cb5d4aec1da7286717bdbe08ce891f53154a47/alpine3/Dockerfile
@@ -7,10 +7,11 @@ ENV DM_VERSION=v0.16.2
 ENV DM_RELEASE=docker-machine-Linux-x86_64
 ENV DM_BASE_URL=https://github.com/docker/machine/releases/download/${DM_VERSION}
 ENV DM_URL=${DM_BASE_URL}/${DM_RELEASE}
-ENV DO_VERSION=20.10.2
+ENV DO_VERSION=20.10.7
 ENV DO_URL=https://download.docker.com/linux/static/stable/x86_64/docker-${DO_VERSION}.tgz
-ENV DC_VERSION=1.28.2
+ENV DC_VERSION=1.29.2
 ENV DC_URL=https://github.com/docker/compose/releases/download/${DC_VERSION}/docker-compose-Linux-x86_64
+ENV ANSIBLE_VERSION=4.1.0
 
 RUN echo "install system deps " \
     && apk --update add curl \
@@ -36,7 +37,7 @@ RUN echo "install system deps " \
         build-base \
         cargo \
     && pip3 install --upgrade pip cffi \
-    && pip3 install --upgrade ansible==2.10.4 \
+    && pip3 install --upgrade ansible==${ANSIBLE_VERSION} \
     && pip3 install --upgrade pycrypt pywinrm \
     && apk --update add sshpass openssh-client rsync \
     && mkdir -p /etc/ansible \

--- a/provision/ansible/inventory/digital_ocean.py
+++ b/provision/ansible/inventory/digital_ocean.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 DigitalOcean external inventory script

--- a/provision/docker-compose.yml
+++ b/provision/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.7'
 services:
   ops:
-    image: 'joaodubas/ops-tools:0.0.12'
+    image: 'joaodubas/ops-tools:1.0.0'
     build:
       context: .
     init: true

--- a/provision/terraform/versions.tf
+++ b/provision/terraform/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     digitalocean = {
-      source = "terraform-providers/digitalocean"
+      source = "digitalocean/digitalocean"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
Time to upgrade terraform, ansible, and company.

1. terraform to 1.0
2. docker to 20.10.7
3. docker-compose to 1.29.2
4. ansible to 4.1.0

Besides that, adjust definitions for terraform and playbooks.