### PR TITLE
Use gosu to improve coder execution

### DIFF
--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
     g++ \
     gcc \
     git \
+    gosu \
     gpg \
     gpg-agent \
     jq \
@@ -177,9 +178,9 @@ RUN echo "Downloading ${CODE_URL}" \
   && chmod 755 ${PWD}/${CODE_PATH}/bin/code-server
 
 # runtime
-USER coder
-WORKDIR ${HOME}/project
-VOLUME ${HOME}/exercism
+WORKDIR /home/coder/project
+VOLUME /home/coder/exercism
 EXPOSE 8443
-ENTRYPOINT ["code-server"]
-CMD ["-d", "$PWD"]
+COPY ./scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["code-server", "--config", "/home/coder/.config/code-server/config.yml"]

--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -166,7 +166,7 @@ RUN curl -LO ${GRPC_URL} \
   && rm ${GRPC_FILE}
 
 # fetch/install code server
-ENV CODE_VERSION 3.11.1
+ENV CODE_VERSION 3.12.0
 ENV CODE_RELEASE v${CODE_VERSION}
 ENV CODE_PATH code-server-${CODE_VERSION}-linux-amd64
 ENV CODE_FILE ${CODE_PATH}.tar.gz

--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -165,7 +165,7 @@ RUN curl -LO ${GRPC_URL} \
   && rm ${GRPC_FILE}
 
 # fetch/install code server
-ENV CODE_VERSION 3.10.2
+ENV CODE_VERSION 3.11.1
 ENV CODE_RELEASE v${CODE_VERSION}
 ENV CODE_PATH code-server-${CODE_VERSION}-linux-amd64
 ENV CODE_FILE ${CODE_PATH}.tar.gz

--- a/ide/config/code-server/config.yml
+++ b/ide/config/code-server/config.yml
@@ -1,0 +1,9 @@
+---
+auth: password
+cert: false
+disable-telemetry: true
+disable-update-check: true
+bind-addr: '0.0.0.0:8443'
+user-data-dir: '/home/coder/project'
+extensions-dir: '/home/coder/.cache/code-server'
+verbose: true

--- a/ide/docker-compose.yml
+++ b/ide/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.7'
 services:
   coder:
-    image: 'joaodubas/code-server:3.10.2'
+    image: 'joaodubas/code-server:3.11.1'
     build:
       context: .
     init: true

--- a/ide/docker-compose.yml
+++ b/ide/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     restart: unless-stopped
     environment:
       NODE_ENV: production
+      PASSWORD: '${CODER_PASSWORD:-password}'
       SERVICE_URL: 'https://open-vsx.org/vscode/gallery'
       ITEM_URL: 'https://open-vsx.org/vscode/item'
     volumes:
@@ -20,8 +21,7 @@ services:
       - 'cache_data:/home/coder/.cache'
       - './config/nvim:/home/coder/.config/nvim'
       - './config/zsh:/home/coder/.config/zsh'
-    working_dir: /opt/src
-    command: '--user-data-dir /opt/src --bind-addr 0.0.0.0:8443 --auth password'
+      - './config/code-server:/home/coder/.config/code-server'
 volumes:
   src_data: {}
   gopath_data: {}

--- a/ide/docker-compose.yml
+++ b/ide/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.7'
 services:
   coder:
-    image: 'joaodubas/code-server:3.11.1'
+    image: 'joaodubas/code-server:3.12.0'
     build:
       context: .
     init: true

--- a/ide/docker-compose.yml
+++ b/ide/docker-compose.yml
@@ -13,22 +13,18 @@ services:
       SERVICE_URL: 'https://open-vsx.org/vscode/gallery'
       ITEM_URL: 'https://open-vsx.org/vscode/item'
     volumes:
-      - './config/nvim:/home/coder/.config/nvim'
-      - './config/zsh:/home/coder/.config/zsh'
       - 'src_data:/opt/src'
       - 'gopath_data:/go'
-      - 'exercism_config_data:/home/coder/.config/exercism'
-      - 'zsh_cache_data:/home/coder/.cache/zsh'
-      - 'asdf_cache_data:/home/coder/.cache/asdf'
+      - 'exercism_data:/home/coder/exercism'
+      - 'config_data:/home/coder/.config'
+      - 'cache_data:/home/coder/.cache'
+      - './config/nvim:/home/coder/.config/nvim'
+      - './config/zsh:/home/coder/.config/zsh'
     working_dir: /opt/src
     command: '--user-data-dir /opt/src --bind-addr 0.0.0.0:8443 --auth password'
 volumes:
   src_data: {}
   gopath_data: {}
-  exercism_config_data: {}
-  zsh_cache_data: {}
-  asdf_cache_data: {}
-networks:
-  default:
-    external:
-      name: proxy_upstream
+  exercism_data: {}
+  config_data: {}
+  cache_data: {}

--- a/ide/scripts/docker-entrypoint.sh
+++ b/ide/scripts/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+if [ "$1" = 'code-server' ]; then
+    chown --recursive coder:coder /home/coder
+    gosu coder mkdir -p /home/coder/.cache/zsh
+    exec gosu coder "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Time to improve coder execution.

1. Use [`gosu`][0] to step down from root to non-privileged user.
2. Create a configuration for coder
3. Remove external network
4. Mount [xdg directories][1], for better backup and maintenance between installations
5. Upgrade coder to version 3.12.0

[0]: https://github.com/tianon/gosu
[1]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html