### PR TITLE
Update some softwares

### DIFF
--- a/gitea/docker-compose.yml
+++ b/gitea/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 
 services:
   git:
-    image: 'gitea/gitea:1.15.0'
+    image: 'gitea/gitea:1.15.7'
     environment:
       APP_NAME: ${GIT_APP_NAME:-gitea}
       USER_UID: ${UID:-1000}
@@ -25,7 +25,7 @@ services:
     ports:
       - '222:22'
   ci:
-    image: 'drone/drone:2.1.0'
+    image: 'drone/drone:2.6.0'
     environment:
       DRONE_DATABASE_DRIVER: ${DRONE_DATABASE_DRIVER:-sqlite3}
       DRONE_DATABASE_DATASOURCE: ${DRONE_DATABASE_DATASOURCE:-/data/database.sqlite}
@@ -45,7 +45,7 @@ services:
     networks:
       - git_cicd_net
   worker:
-    image: 'drone/drone-runner-docker:1.6.3'
+    image: 'drone/drone-runner-docker:1.8.0'
     environment:
       DRONE_RPC_PROTO: ${WORKER_RPC_PROTO:-http}
       DRONE_RPC_HOST: ${WORKER_RPC_HOST:-ci}

--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -90,17 +90,17 @@ ENV ZDOTDIR ${XDG_CONFIG_HOME}/zsh
 
 # fetch/install asdf
 ENV PATH ${XDG_CONFIG_HOME}/asdf/bin:$PATH
-ENV ASDF_VERSION v0.8.0
+ENV ASDF_VERSION v0.9.0
 RUN git clone https://github.com/asdf-vm/asdf.git ${ASDF_HOME_DIR} --branch ${ASDF_VERSION} \
   && echo '\n. ${ASDF_HOME_DIR}/asdf.sh' >> ${HOME}/.zshrc.ext \
   && echo '\n. ${ASDF_HOME_DIR}/completions/asdf.bash' >> ${HOME}/.zshrc.ext
 
 # configure asdf plugins
-ENV GO_VERSION 1.16.3
-ENV ERLANG_VERSION 23.3.1
-ENV ELIXIR_VERSION 1.11.4-otp-23
-ENV NODE_VERSION 15.14.0
-ENV YARN_VERSION 1.22.10
+ENV GO_VERSION 1.17.5
+ENV ERLANG_VERSION 24.1.7
+ENV ELIXIR_VERSION 1.12.3-otp-24
+ENV NODE_VERSION 17.2.0
+ENV YARN_VERSION 1.22.17
 RUN asdf plugin-add golang \
   && asdf plugin-add erlang \
   && asdf plugin-add elixir \
@@ -143,7 +143,7 @@ RUN curl -L -XGET ${EXERCISM_URL} | tar xz \
   && rm -rf ./*
 
 # fetch/install ripgrep
-ENV RIPGREP_VERSION 12.1.1
+ENV RIPGREP_VERSION 13.0.0
 ENV RIPGREP_FILE ripgrep_${RIPGREP_VERSION}_amd64.deb
 ENV RIPGREP_URL https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}/${RIPGREP_FILE}
 RUN curl -LO ${RIPGREP_URL} \
@@ -153,7 +153,7 @@ ENV FZF_DEFAULT_COMMAND rg --files
 ENV FZF_DEFAULT_OPTS -m --height 50% --border
 
 # fetch/install grpc
-ENV GRPC_VERSION 3.15.8
+ENV GRPC_VERSION 3.19.1
 ENV GRPC_PATH protoc-${GRPC_VERSION}-linux-x86_64
 ENV GRPC_FILE ${GRPC_PATH}.zip
 ENV GRPC_URL https://github.com/protocolbuffers/protobuf/releases/download/v${GRPC_VERSION}/${GRPC_FILE}
@@ -166,7 +166,7 @@ RUN curl -LO ${GRPC_URL} \
   && rm ${GRPC_FILE}
 
 # fetch/install code server
-ENV CODE_VERSION 3.12.0
+ENV CODE_VERSION 4.0.0
 ENV CODE_RELEASE v${CODE_VERSION}
 ENV CODE_PATH code-server-${CODE_VERSION}-linux-amd64
 ENV CODE_FILE ${CODE_PATH}.tar.gz

--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04 AS base
 
 # install system deps
 ENV DEBIAN_FRONTEND noninteractive
@@ -165,6 +165,8 @@ RUN curl -LO ${GRPC_URL} \
   && chmod --recursive o+r /usr/local/include \
   && rm ${GRPC_FILE}
 
+FROM base AS code-server
+
 # fetch/install code server
 ENV CODE_VERSION 4.0.0
 ENV CODE_RELEASE v${CODE_VERSION}
@@ -184,3 +186,25 @@ EXPOSE 8443
 COPY ./scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["code-server", "--config", "/home/coder/.config/code-server/config.yml"]
+
+FROM base AS openvscode-server
+
+# fetch/install code server
+ENV OPENVSCODE_VERSION 1.63.0
+ENV OPENVSCODE_RELEASE openvscode-server-v${OPENVSCODE_VERSION}
+ENV OPENVSCODE_PATH openvscode-server-v${OPENVSCODE_VERSION}-linux-x64
+ENV OPENVSCODE_FILE ${OPENVSCODE_PATH}.tar.gz
+ENV OPENVSCODE_URL https://github.com/gitpod-io/openvscode-server/releases/download/${OPENVSCODE_RELEASE}/${OPENVSCODE_FILE}
+WORKDIR /usr/local/lib
+RUN echo "Downloading ${OPENVSCODE_URL}" \
+  && curl -L ${OPENVSCODE_URL} | tar xz \
+  && sed -i 's/^ROOT=.*$/ROOT=\/usr\/local\/lib\/\$\{OPENVSCODE_PATH\}/' ${OPENVSCODE_PATH}/server.sh \
+  && ln -s ${PWD}/${OPENVSCODE_PATH}/server.sh /usr/local/bin/openvscode-server
+
+# runtime
+WORKDIR /home/coder/project
+VOLUME /home/coder/exercism
+EXPOSE 3000
+COPY ./scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["openvscode-server", "--port", "3000", "--host", "0.0.0.0"]

--- a/ide/docker-compose.yml
+++ b/ide/docker-compose.yml
@@ -1,5 +1,16 @@
 ---
 version: '3.7'
+
+x-volumes: &volumes
+  - 'src_data:/opt/src'
+  - 'gopath_data:/go'
+  - 'exercism_data:/home/coder/exercism'
+  - 'config_data:/home/coder/.config'
+  - 'cache_data:/home/coder/.cache'
+  - './config/nvim:/home/coder/.config/nvim'
+  - './config/zsh:/home/coder/.config/zsh'
+  - './config/code-server:/home/coder/.config/code-server'
+
 services:
   coder:
     image: 'joaodubas/code-server:4.0.0'
@@ -14,15 +25,7 @@ services:
       PASSWORD: '${CODER_PASSWORD:-password}'
       SERVICE_URL: 'https://open-vsx.org/vscode/gallery'
       ITEM_URL: 'https://open-vsx.org/vscode/item'
-    volumes:
-      - 'src_data:/opt/src'
-      - 'gopath_data:/go'
-      - 'exercism_data:/home/coder/exercism'
-      - 'config_data:/home/coder/.config'
-      - 'cache_data:/home/coder/.cache'
-      - './config/nvim:/home/coder/.config/nvim'
-      - './config/zsh:/home/coder/.config/zsh'
-      - './config/code-server:/home/coder/.config/code-server'
+    volumes: *volumes
   openvscode:
     image: 'joaodubas/openvscode-server:1.63.0'
     build:
@@ -31,15 +34,8 @@ services:
     init: true
     hostname: openvscode
     restart: unless-stopped
-    volumes:
-      - 'src_data:/opt/src'
-      - 'gopath_data:/go'
-      - 'exercism_data:/home/coder/exercism'
-      - 'config_data:/home/coder/.config'
-      - 'cache_data:/home/coder/.cache'
-      - './config/nvim:/home/coder/.config/nvim'
-      - './config/zsh:/home/coder/.config/zsh'
-      - './config/code-server:/home/coder/.config/code-server'
+    volumes: *volumes
+
 volumes:
   src_data: {}
   gopath_data: {}

--- a/ide/docker-compose.yml
+++ b/ide/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: 'joaodubas/code-server:4.0.0'
     build:
       context: .
+      target: code-server
     init: true
     hostname: coder
     restart: unless-stopped
@@ -13,6 +14,23 @@ services:
       PASSWORD: '${CODER_PASSWORD:-password}'
       SERVICE_URL: 'https://open-vsx.org/vscode/gallery'
       ITEM_URL: 'https://open-vsx.org/vscode/item'
+    volumes:
+      - 'src_data:/opt/src'
+      - 'gopath_data:/go'
+      - 'exercism_data:/home/coder/exercism'
+      - 'config_data:/home/coder/.config'
+      - 'cache_data:/home/coder/.cache'
+      - './config/nvim:/home/coder/.config/nvim'
+      - './config/zsh:/home/coder/.config/zsh'
+      - './config/code-server:/home/coder/.config/code-server'
+  openvscode:
+    image: 'joaodubas/openvscode-server:1.63.0'
+    build:
+      context: .
+      target: openvscode-server
+    init: true
+    hostname: openvscode
+    restart: unless-stopped
     volumes:
       - 'src_data:/opt/src'
       - 'gopath_data:/go'

--- a/ide/docker-compose.yml
+++ b/ide/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.7'
 services:
   coder:
-    image: 'joaodubas/code-server:3.12.0'
+    image: 'joaodubas/code-server:4.0.0'
     build:
       context: .
     init: true

--- a/ide/scripts/docker-entrypoint.sh
+++ b/ide/scripts/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ "$1" = 'code-server' ]; then
+if [ "$1" = 'code-server' ] || [ "$1" = 'openvscode-server' ]; then
     chown --recursive coder:coder /home/coder
     gosu coder mkdir -p /home/coder/.cache/zsh
     exec gosu coder "$@"

--- a/internal/appsmith/docker-compose.yml
+++ b/internal/appsmith/docker-compose.yml
@@ -13,7 +13,7 @@ x-config: &config
 
 services:
   app:
-    image: 'appsmith/appsmith-editor:v1.5.26'
+    image: 'appsmith/appsmith-editor:v1.6.1'
     init: true
     hostname: app
     restart: unless-stopped
@@ -21,7 +21,7 @@ services:
     volumes:
       - './config/nginx/app.conf.template:/nginx.conf.template'
   server:
-    image: 'appsmith/appsmith-server:v1.5.26'
+    image: 'appsmith/appsmith-server:v1.6.1'
     init: true
     hostname: server
     restart: unless-stopped

--- a/provision/terraform/dev.tf
+++ b/provision/terraform/dev.tf
@@ -51,6 +51,13 @@ resource "digitalocean_record" "dev_coder" {
   value = digitalocean_droplet.dev_server.ipv4_address
 }
 
+resource "digitalocean_record" "dev_openvscode" {
+  domain = digitalocean_domain.dev_default.name
+  type = "A"
+  name = "openvscode"
+  value = digitalocean_droplet.dev_server.ipv4_address
+}
+
 resource "digitalocean_record" "dev_pgadmin" {
   domain = digitalocean_domain.dev_default.name
   type = "A"


### PR DESCRIPTION
* asdf  from v0.8.0  to v0.9.0
* golang from 1.16.3 to 1.17.5
* erlang from 23.3.1 to 24.1.7
* elixir from 1.11.4-otp-23 to 1.12.3-otp-24
* node from 15.14.0 to 17.2.0
* yarn from 1.22.10 to 1.22.17
* ripgrep from 12.1.1 to 13.0.0
* protobuf from 3.15.8 to 3.19.1
* code-server from 3.12.0 to 4.0.0
* gitea from 1.15.0 to 1.15.7
* drone from 2.1.0 to 2.6.0
* drone-runner-docker from 1.6.3 to 1.8.00
* appsmith from 1.5.26 to 1.6.1

Also added [openvscode-server][0] ide.

[0]: https://github.com/gitpod-io/openvscode-server