### PR TITLE
Update IDE versions and runtimes

### DIFF
--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -102,11 +102,11 @@ RUN git clone https://github.com/asdf-vm/asdf.git ${ASDF_DIR} --branch ${ASDF_VE
   && echo 'autoload -Uz compinit && compinit' >> ${HOME}/.zshrc.ext
 
 # configure asdf plugins
-ENV GO_VERSION 1.17.5
-ENV ERLANG_VERSION 24.1.7
-ENV ELIXIR_VERSION 1.12.3-otp-24
-ENV NODE_VERSION 17.2.0
-ENV YARN_VERSION 1.22.17
+ENV GO_VERSION 1.18
+ENV ERLANG_VERSION 24.3.2
+ENV ELIXIR_VERSION 1.13.3-otp-24
+ENV NODE_VERSION 17.8.0
+ENV YARN_VERSION 1.22.18
 RUN asdf plugin-add golang \
   && asdf plugin-add erlang \
   && asdf plugin-add elixir \
@@ -176,11 +176,11 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 FROM base AS code-server
 
 # fetch/install code server
-ENV CODE_VERSION 4.0.2
+ENV CODE_VERSION 4.3.0
 ENV CODE_RELEASE v${CODE_VERSION}
 ENV CODE_PATH code-server-${CODE_VERSION}-linux-amd64
 ENV CODE_FILE ${CODE_PATH}.tar.gz
-ENV CODE_URL https://github.com/cdr/code-server/releases/download/${CODE_RELEASE}/${CODE_FILE}
+ENV CODE_URL https://github.com/coder/code-server/releases/download/${CODE_RELEASE}/${CODE_FILE}
 WORKDIR /usr/local/lib
 RUN echo "Downloading ${CODE_URL}" \
   && curl -L ${CODE_URL} | tar xz \
@@ -195,7 +195,7 @@ CMD ["code-server", "--config", "/home/coder/.config/code-server/config.yml"]
 FROM base AS openvscode-server
 
 # fetch/install code server
-ENV OPENVSCODE_VERSION 1.64.0
+ENV OPENVSCODE_VERSION 1.66.1
 ENV OPENVSCODE_RELEASE openvscode-server-v${OPENVSCODE_VERSION}
 ENV OPENVSCODE_PATH openvscode-server-v${OPENVSCODE_VERSION}-linux-x64
 ENV OPENVSCODE_FILE ${OPENVSCODE_PATH}.tar.gz

--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -86,14 +86,16 @@ ENV LANGUAGE en_US.UTF-8
 ENV LANG ${LANGAGUE}
 ENV LC_ALL ${LANGUAGE}
 ENV HOME /home/coder
+ENV LOCAL_BIN_HOME ${HOME}/.local/bin
+ENV LOCAL_SRC_HOME ${HOME}/.local/src
 ENV XDG_CONFIG_HOME ${HOME}/.config
 ENV XDG_DATA_HOME ${HOME}/.local/share
 ENV XDG_CACHE_HOME ${HOME}/.cache
-ENV ASDF_DIR ${XDG_CONFIG_HOME}/asdf
-ENV ASDF_DATA_DIR ${XDG_CACHE_HOME}/asdf
 ENV ZDOTDIR ${XDG_CONFIG_HOME}/zsh
 
 # fetch/install asdf
+ENV ASDF_DIR ${LOCAL_SRC_HOME}/asdf
+ENV ASDF_DATA_DIR ${XDG_CACHE_HOME}/asdf
 ENV PATH ${ASDF_DIR}/bin:$PATH
 ENV ASDF_VERSION v0.9.0
 RUN git clone https://github.com/asdf-vm/asdf.git ${ASDF_DIR} --branch ${ASDF_VERSION} \
@@ -119,16 +121,16 @@ RUN asdf plugin-add golang \
   && echo "yarn $YARN_VERSION" >> /home/coder/.tool-versions
 
 # configure golang
-ENV GOPATH ${HOME}/.config/go
+ENV GOPATH ${XDG_DATA_HOME}/go
 ENV PATH ${GOPATH}/bin:/usr/local/bin:${PATH}
 RUN mkdir -p "${GOPATH}/src" "${GOPATH}/bin" \
   && chmod -R 777 "${GOPATH}"
 
 # fetch/install pyenv
-ENV PYENV_ROOT ${XDG_CONFIG_HOME}/pyenv
+ENV PYENV_ROOT ${LOCAL_SRC_HOME}/pyenv
+ENV PATH ${PYENV_ROOT}/bin:$PATH
 RUN curl https://pyenv.run | bash \
-  && echo '\nexport PATH=${PYENV_ROOT}/bin:${PATH}' >> ${HOME}/.zshrc.ext \
-  && echo 'eval "$(pyenv init --path)"' >> ${HOME}/.zshrc.ext \
+  && echo '\neval "$(pyenv init --path)"' >> ${HOME}/.zshrc.ext \
   && echo 'eval "$(pyenv virtualenv-init -)"' >> ${HOME}/.zshrc.ext
 
 USER root

--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -16,19 +16,24 @@ RUN apt-get update \
     dirmngr \
     g++ \
     gcc \
+    gfortran \
     git \
     gosu \
     gpg \
     gpg-agent \
     jq \
+    libbz2-1.0 \
     libbz2-dev \
     libc6-dev \
+    libcurl3-dev \
     libffi-dev \
     liblzma-dev \
+    liblzma5 \
     libncurses-dev \
     libncurses5-dev \
     libncursesw5-dev \
     libodbc1 \
+    libpcre2-dev \
     libreadline-dev \
     libsctp-dev \
     libsctp1 \
@@ -54,9 +59,10 @@ RUN apt-get update \
     unzip \
     uuid-dev \
     wget \
+    xorg-dev \
     xz-utils \
-    zsh \
     zlib1g-dev \
+    zsh \
   && echo 'install gh for neovim lsp installer' \
   && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/etc/apt/trusted.gpg.d/githubcli-archive-keyring.gpg \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/trusted.gpg.d/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
@@ -107,6 +113,7 @@ RUN git clone https://github.com/asdf-vm/asdf.git ${ASDF_DIR} --branch ${ASDF_VE
 ENV GO_VERSION 1.18
 ENV ERLANG_VERSION 24.3.2
 ENV ELIXIR_VERSION 1.13.3-otp-24
+ENV R_VERSION 4.1.3
 ENV NODE_VERSION 17.8.0
 ENV YARN_VERSION 1.22.18
 RUN asdf plugin-add golang \
@@ -114,9 +121,11 @@ RUN asdf plugin-add golang \
   && asdf plugin-add elixir \
   && asdf plugin-add nodejs \
   && asdf plugin-add yarn \
+  && asdf plugin-add R \
   && echo "golang $GO_VERSION" > /home/coder/.tool-versions \
   && echo "erlang $ERLANG_VERSION" >> /home/coder/.tool-versions \
   && echo "elixir $ELIXIR_VERSION" >> /home/coder/.tool-versions \
+  && echo "R $R_VERSION" >> /home/coder/.tool-versions \
   && echo "nodejs $NODE_VERSION" >> /home/coder/.tool-versions \
   && echo "yarn $YARN_VERSION" >> /home/coder/.tool-versions
 

--- a/ide/README.md
+++ b/ide/README.md
@@ -1,22 +1,27 @@
-# code server with a twist
+# online visual studio code with a twist
 
-Run [`code-server`][0] with support to:
+Run [`code-server`][code-server] or [`openvscode-server`][openvscode] with support to:
 
-1. [asdf (0.7.4)][1]
-2. [python (3.7.4)][2]
-3. [golang (1.12.9)][3]
-4. [erlang/otp (22.0.7)][4]
-5. [elixir (1.9.1)][5]
-6. [node (12.8.1)][6]
+1. [asdf (0.9.0)][asdf]
+1. [pyenv (2.2.4)][pyenv]
+1. [golang (1.18)][golang]
+1. [erlang/otp (24.3.2)][erlang]
+1. [elixir (1.13.3)][elixir]
+1. [node (17.8.0)][node]
 
-## Run the server
+## Run the servers
 
-Invoke `docker-compose up -d` and this will start the server.
+Invoke `docker-compose up -d` and this will start the servers.
 
-[0]: https://github.com/codercom/code-server
-[1]: https://asdf-vm.com/#/
-[2]: https://github.com/danhper/asdf-python
-[3]: https://github.com/kennyp/asdf-golang
-[4]: https://github.com/asdf-vm/asdf-erlang
-[5]: https://github.com/asdf-vm/asdf-elixir
-[6]: https://github.com/asdf-vm/asdf-nodejs
+## Notes
+
+I'm still deciding which code editor is the best one, that's why I'm keeping both for now.
+
+[code-server]: https://github.com/codercom/code-server
+[openvscode]: https://github.com/gitpod-io/openvscode-server
+[asdf]: https://asdf-vm.com/#/
+[pyenv]: https://github.com/pyenv/pyenv
+[golang]: https://github.com/kennyp/asdf-golang
+[erlang]: https://github.com/asdf-vm/asdf-erlang
+[elixr]: https://github.com/asdf-vm/asdf-elixir
+[node]: https://github.com/asdf-vm/asdf-nodejs

--- a/ide/README.md
+++ b/ide/README.md
@@ -7,6 +7,7 @@ Run [`code-server`][code-server] or [`openvscode-server`][openvscode] with suppo
 1. [golang (1.18)][golang]
 1. [erlang/otp (24.3.2)][erlang]
 1. [elixir (1.13.3)][elixir]
+1. [R (4.1.3)][R]
 1. [node (17.8.0)][node]
 
 ## Run the servers
@@ -23,5 +24,6 @@ I'm still deciding which code editor is the best one, that's why I'm keeping bot
 [pyenv]: https://github.com/pyenv/pyenv
 [golang]: https://github.com/kennyp/asdf-golang
 [erlang]: https://github.com/asdf-vm/asdf-erlang
+[R]: https://github.com/asdf-community/asdf-r
 [elixr]: https://github.com/asdf-vm/asdf-elixir
 [node]: https://github.com/asdf-vm/asdf-nodejs

--- a/ide/docker-compose.yml
+++ b/ide/docker-compose.yml
@@ -14,7 +14,7 @@ x-volumes: &volumes
 
 services:
   coder:
-    image: 'joaodubas/code-server:4.0.2'
+    image: 'joaodubas/code-server:4.3.0'
     build:
       context: .
       target: code-server
@@ -28,7 +28,7 @@ services:
       ITEM_URL: 'https://open-vsx.org/vscode/item'
     volumes: *volumes
   openvscode:
-    image: 'joaodubas/openvscode-server:1.64.0'
+    image: 'joaodubas/openvscode-server:1.66.1'
     build:
       context: .
       target: openvscode-server

--- a/ide/docker-compose.yml
+++ b/ide/docker-compose.yml
@@ -3,11 +3,12 @@ version: '3.7'
 
 x-volumes: &volumes
   - 'src_data:/opt/src'
-  - 'gopath_data:/go'
   - 'exercism_data:/home/coder/exercism'
   - 'nvim_config_data:/home/coder/.config'
   - 'nvim_cache_data:/home/coder/.cache'
   - 'nvim_share_data:/home/coder/.local/share'
+  - 'gopath_data:/home/coder/.local/share/go'
+  - 'pyenv_versions_data:/home/coder/.local/src/pyenv/versions'
   - './config/nvim:/home/coder/.config/nvim'
   - './config/zsh:/home/coder/.config/zsh'
   - './config/code-server:/home/coder/.config/code-server'
@@ -44,3 +45,4 @@ volumes:
   nvim_config_data: {}
   nvim_cache_data: {}
   nvim_share_data: {}
+  pyenv_versions_data: {}


### PR DESCRIPTION
Introduce some changes to the way we handle xdg paths:

1. asdf and pyenv installed in ~/.local/src
2. asdf use XDG_CACHE_HOME to keep applications

In addition we upgrade both runtimes and IDE versions:

* golang 1.17.5..1.18
* erlang 24.1.7..24.3.2
* elixir 1.12.3-otp-24..1.13.3-otp-24
* node 17.2.0..17.8.0
* yarn 1.22.17..1.22.18
* coder 4.0.2..4.3.0
* openvscode 1.64.0..1.66.1

Finally, add R plugin for asdf.