### PR TITLE
chore (ide): upgrade IDEs and runtimes

### DIFF
--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -187,7 +187,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 FROM base AS code-server
 
 # fetch/install code server
-ENV CODE_VERSION 4.3.0
+ENV CODE_VERSION 4.4.0
 ENV CODE_RELEASE v${CODE_VERSION}
 ENV CODE_PATH code-server-${CODE_VERSION}-linux-amd64
 ENV CODE_FILE ${CODE_PATH}.tar.gz
@@ -206,7 +206,7 @@ CMD ["code-server", "--config", "/home/coder/.config/code-server/config.yml"]
 FROM base AS openvscode-server
 
 # fetch/install code server
-ENV OPENVSCODE_VERSION 1.66.1
+ENV OPENVSCODE_VERSION 1.67.0
 ENV OPENVSCODE_RELEASE openvscode-server-v${OPENVSCODE_VERSION}
 ENV OPENVSCODE_PATH openvscode-server-v${OPENVSCODE_VERSION}-linux-x64
 ENV OPENVSCODE_FILE ${OPENVSCODE_PATH}.tar.gz

--- a/ide/Dockerfile
+++ b/ide/Dockerfile
@@ -103,18 +103,18 @@ ENV ZDOTDIR ${XDG_CONFIG_HOME}/zsh
 ENV ASDF_DIR ${LOCAL_SRC_HOME}/asdf
 ENV ASDF_DATA_DIR ${XDG_CACHE_HOME}/asdf
 ENV PATH ${ASDF_DIR}/bin:$PATH
-ENV ASDF_VERSION v0.9.0
+ENV ASDF_VERSION v0.10.0
 RUN git clone https://github.com/asdf-vm/asdf.git ${ASDF_DIR} --branch ${ASDF_VERSION} \
   && echo '\n. ${ASDF_DIR}/asdf.sh' >> ${HOME}/.zshrc.ext \
   && echo 'fpath=(${ASDF_DIR}/completions $fpath)' >> ${HOME}/.zshrc.ext \
   && echo 'autoload -Uz compinit && compinit' >> ${HOME}/.zshrc.ext
 
 # configure asdf plugins
-ENV GO_VERSION 1.18
-ENV ERLANG_VERSION 24.3.2
-ENV ELIXIR_VERSION 1.13.3-otp-24
-ENV R_VERSION 4.1.3
-ENV NODE_VERSION 17.8.0
+ENV GO_VERSION 1.18.1
+ENV ERLANG_VERSION 24.3.4
+ENV ELIXIR_VERSION 1.13.4-otp-24
+ENV R_VERSION 4.2.0
+ENV NODE_VERSION 18.1.0
 ENV YARN_VERSION 1.22.18
 RUN asdf plugin-add golang \
   && asdf plugin-add erlang \
@@ -167,7 +167,7 @@ RUN curl -LO ${RIPGREP_URL} \
   && rm ${RIPGREP_FILE}
 
 # fetch/install grpc
-ENV GRPC_VERSION 3.19.1
+ENV GRPC_VERSION 3.20.1
 ENV GRPC_PATH protoc-${GRPC_VERSION}-linux-x86_64
 ENV GRPC_FILE ${GRPC_PATH}.zip
 ENV GRPC_URL https://github.com/protocolbuffers/protobuf/releases/download/v${GRPC_VERSION}/${GRPC_FILE}

--- a/ide/docker-compose.yml
+++ b/ide/docker-compose.yml
@@ -15,7 +15,7 @@ x-volumes: &volumes
 
 services:
   coder:
-    image: 'joaodubas/code-server:4.3.0'
+    image: 'joaodubas/code-server:4.4.0'
     build:
       context: .
       target: code-server
@@ -29,7 +29,7 @@ services:
       ITEM_URL: 'https://open-vsx.org/vscode/item'
     volumes: *volumes
   openvscode:
-    image: 'joaodubas/openvscode-server:1.66.1'
+    image: 'joaodubas/openvscode-server:1.67.0'
     build:
       context: .
       target: openvscode-server


### PR DESCRIPTION
Upgrade IDEs:

* coder from 4.3.0 to 4.4.0
* openvscode from 1.66.1 to 1.67.0

Upgrade runtimes:

* asdf from0.9.0 to 0.10.0
* go from 1.18 to 1.18.1
* erlang from 24.3.2 to 24.3.4
* elixir from 1.13.3 to 1.13.4
* r from 4.1.3 to 4.2.0
* node from 17.8.0 to 18.1.0
* grpc from 3.19.1 to 3.20.1