### PR TITLE
Upgrade runtimes for git apps

### DIFF
--- a/gitea/docker-compose.yml
+++ b/gitea/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   git:
-    image: 'gitea/gitea:1.19.4'
+    image: 'gitea/gitea:1.21.4'
     init: true
     environment:
       APP_NAME: ${GIT_APP_NAME:-gitea}
@@ -30,7 +30,7 @@ services:
   dependency_bot:
     image: 'renovate/renovate:35.48.2-slim'
   ci:
-    image: 'drone/drone:2.17.0'
+    image: 'drone/drone:2.22.0'
     init: true
     environment:
       DRONE_DATABASE_DRIVER: ${DRONE_DATABASE_DRIVER:-sqlite3}
@@ -82,7 +82,7 @@ services:
   # TODO (jpd): to start renovate we must change ownership of renovate_data to
   # ubuntu user
   renovate:
-    image: 'renovate/renovate:35.117.3'
+    image: 'renovate/renovate:37.162.1'
     init: true
     environment:
       GITHUB_COM_TOKEN: ${GITHUB_COM_TOKEN:-token}


### PR DESCRIPTION
Upgrade:

1. gitea from [1.19.4][0] to [1.21.4][1]
2. drone from [2.17.0 to 2.22.0][2]
3. renovate from [35.117.3 to 37.162.1][3]

[0]: https://blog.gitea.com/release-of-1.19.4/
[1]: https://blog.gitea.com/release-of-1.21.4/
[2]: https://github.com/harness/gitness/compare/v2.17.0...v2.22.0
[3]: https://github.com/renovatebot/renovate/compare/35.117.3...37.165.0