### PR TITLE
Experiment with redis alternatives

### DIFF
--- a/streams/consumer-py/consumer.py
+++ b/streams/consumer-py/consumer.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 import time
 
@@ -17,7 +18,9 @@ def consume():
 
 
 def conn(log: logging.Logger) -> redis.Redis:
-    cli = redis.Redis(host='streams', port=6379)
+    stream_host = os.environ.get('STREAM_HOST', 'stream')
+    stream_port = os.environ.get('STREAM_PORT', '6379')
+    cli = redis.Redis(host=stream_host, port=int(stream_port))
     try:
         cli.ping()
     except redis.ConnectionError as e:

--- a/streams/consumer/main.go
+++ b/streams/consumer/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -19,7 +20,7 @@ const (
 )
 
 func main() {
-	fmt.Println("consumer")
+	log.Println("consumer")
 	c := conn()
 	group(c)
 	mID := ">"
@@ -32,7 +33,9 @@ func main() {
 
 // conn stablish a connection with redis and return it.
 func conn() redis.Conn {
-	c, err := redis.Dial("tcp", "streams:6379")
+	stream_host := os.Getenv("STREAM_HOST")
+	stream_port := os.Getenv("STREAM_PORT")
+	c, err := redis.Dial("tcp", fmt.Sprintf("%s:%s", stream_host, stream_port))
 	if err != nil {
 		log.Fatalf("conn: failure to connect with redis instance %v", err)
 	}

--- a/streams/docker-compose.yml
+++ b/streams/docker-compose.yml
@@ -31,6 +31,9 @@ services:
       - streams
       - dragonfly-streams
       - key-streams
+    environment: &stream_configuration
+      STREAM_HOST: *redis_hostname
+      STREAM_PORT: 6379
     volumes:
       - './producer:/go/src/app'
     working_dir: /go/src/app
@@ -44,6 +47,8 @@ services:
     init: true
     restart: unless-stopped
     depends_on: *producer_service_dependencies
+    environment:
+      <<: *stream_configuration
     volumes:
       - './producer-py:/usr/local/src/app'
     command: python producer.py
@@ -54,6 +59,8 @@ services:
     depends_on: &consumer_service_dependencies
       - producer
       - producer-py
+    environment:
+      <<: *stream_configuration
     volumes:
       - './consumer:/go/src/app'
     working_dir: /go/src/app
@@ -66,7 +73,8 @@ services:
     init: true
     restart: unless-stopped
     depends_on: *consumer_service_dependencies
-      - producer-py
+    environment:
+      <<: *stream_configuration
     volumes:
       - './consumer-py:/usr/local/src/app'
     command: python consumer.py

--- a/streams/docker-compose.yml
+++ b/streams/docker-compose.yml
@@ -1,15 +1,36 @@
 ---
 services:
   streams:
-    image: 'redis:7.2.4'
+    image: 'redis:7.2.4-bookworm'
+    init: true
+    hostname: &redis_hostname streams
+    restart: unless-stopped
     environment:
       TERM: xterm-color
+    volumes:
+      - 'redis_data:/data'
     command: redis-server --protected-mode no
+  dragonfly-streams:
+    image: 'docker.dragonflydb.io/dragonflydb/dragonfly:v1.15.1'
+    init: true
+    hostname: &dragonfly_hostname dragonfly-streams
+    restart: unless-stopped
+    volumes:
+      - 'dragonfly_data:/data'
+  key-streams:
+    image: 'eqalpha/keydb:alpine_x86_64_v6.3.4'
+    hostname: &key_hostname key-streams
+    restart: unless-stopped
+    volumes:
+      - 'key_data:/data'
   producer:
     image: &golang_image 'golang:1.22.1'
     init: true
-    depends_on:
+    restart: unless-stopped
+    depends_on: &producer_service_dependencies
       - streams
+      - dragonfly-streams
+      - key-streams
     volumes:
       - './producer:/go/src/app'
     working_dir: /go/src/app
@@ -21,15 +42,16 @@ services:
         POETRY_VERSION: 1.8.2
       context: ./producer-py
     init: true
-    depends_on:
-      - streams
+    restart: unless-stopped
+    depends_on: *producer_service_dependencies
     volumes:
       - './producer-py:/usr/local/src/app'
     command: python producer.py
   consumer:
     image: *golang_image
     init: true
-    depends_on:
+    restart: unless-stopped
+    depends_on: &consumer_service_dependencies
       - producer
       - producer-py
     volumes:
@@ -42,9 +64,13 @@ services:
       args: *python_args
       context: ./consumer-py
     init: true
-    depends_on:
-      - producer
+    restart: unless-stopped
+    depends_on: *consumer_service_dependencies
       - producer-py
     volumes:
       - './consumer-py:/usr/local/src/app'
     command: python consumer.py
+volumes:
+  dragonfly_data: {}
+  key_data: {}
+  redis_data: {}

--- a/streams/producer-py/producer.py
+++ b/streams/producer-py/producer.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 import sys
 import time
 
@@ -38,7 +39,9 @@ def conn(log: logging.Logger) -> redis.Redis:
         Redis connection.
 
     """
-    cli = redis.Redis(host='streams', port=6379)
+    stream_host = os.environ.get('STREAM_HOST', 'stream')
+    stream_port = os.environ.get('STREAM_PORT', '6379')
+    cli = redis.Redis(host=stream_host, port=int(stream_port))
     try:
         cli.ping()
     except redis.ConnectionError as e:

--- a/streams/producer-py/producer.py
+++ b/streams/producer-py/producer.py
@@ -23,6 +23,8 @@ def produce():
             cli,
             'host',
             'host b',
+            'system',
+            os.environ.get('STREAM_HOST', 'stream'),
             'time',
             datetime.datetime.utcnow().astimezone(tz).strftime(rfc3339)
         )

--- a/streams/producer-py/producer.py
+++ b/streams/producer-py/producer.py
@@ -26,7 +26,7 @@ def produce():
             'system',
             os.environ.get('STREAM_HOST', 'stream'),
             'time',
-            datetime.datetime.utcnow().astimezone(tz).strftime(rfc3339)
+            datetime.datetime.now(datetime.UTC).astimezone(tz).strftime(rfc3339)
         )
         time.sleep(1.0)
 

--- a/streams/producer/main.go
+++ b/streams/producer/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/mediocregopher/radix/v3"
@@ -12,7 +13,7 @@ import (
 const StreamName = "log"
 
 func main() {
-	fmt.Println("will do something amazing")
+	log.Println("will do something amazing")
 	c := conn()
 	// TODO: (jpd) this loop should be inside a goroutine.
 	for {
@@ -22,7 +23,9 @@ func main() {
 }
 
 func conn() radix.Client {
-	c, err := radix.NewPool("tcp", "streams:6379", 20)
+	stream_host := os.Getenv("STREAM_HOST")
+	stream_port := os.Getenv("STREAM_PORT")
+	c, err := radix.NewPool("tcp", fmt.Sprintf("%s:%s", stream_host, stream_port), 20)
 	if err != nil {
 		log.Fatalf("conn: failure to connect %v", err)
 	}

--- a/streams/producer/main.go
+++ b/streams/producer/main.go
@@ -17,7 +17,7 @@ func main() {
 	c := conn()
 	// TODO: (jpd) this loop should be inside a goroutine.
 	for {
-		send(c, "host", "host a", "time", time.Now().Format(time.RFC3339Nano))
+		send(c, "host", "host a", "system", os.Getenv("STREAM_HOST"), "time", time.Now().Format(time.RFC3339Nano))
 		time.Sleep(1 * time.Second)
 	}
 }


### PR DESCRIPTION
Since `redis` is no longer an [open-source project][0], I'm experimenting with two alternatives:

1. [`keydb`][1]
2. [`dragonflydb`][2]

For the current usage, both are drop-in replacements for `redis`.

* [`redis streams`][3]
* [`keydb streams`][4]
* [`dragonflydb streams`][5]

To make switching between the different services easier, one can set the variable `STREAM_HOST` to reference the hostname of the desired service.

The messages produced also carry information about the service in use present in the key `system`.

[0]: https://redis.com/blog/redis-adopts-dual-source-available-licensing/
[1]: https://docs.keydb.dev/
[2]: https://www.dragonflydb.io/
[3]: https://redis.io/docs/data-types/streams/
[4]: https://docs.keydb.dev/docs/streams-intro
[5]: https://www.dragonflydb.io/docs/category/streams