### PR TITLE
chore(ci): upgrade runtimes

### DIFF
--- a/gitea/docker-compose.yml
+++ b/gitea/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   git:
-    image: 'gitea/gitea:1.23.0'
+    image: 'gitea/gitea:1.23.5'
     init: true
     hostname: git
     environment:
@@ -31,7 +31,7 @@ services:
   dependency_bot:
     image: 'renovate/renovate:37.421.2-slim'
   ci:
-    image: 'drone/drone:2.25.0'
+    image: 'drone/drone:2.26.0'
     init: true
     hostname: ci
     environment:
@@ -60,7 +60,7 @@ services:
     entrypoint: sleep
     command: 3600d
   worker:
-    image: 'drone/drone-runner-docker:1.8.3'
+    image: 'drone/drone-runner-docker:1.8.4'
     init: true
     hostname: ci_worker
     environment:
@@ -94,7 +94,7 @@ services:
   # TODO (jpd): to start renovate we must change ownership of renovate_data to
   # ubuntu user
   renovate:
-    image: 'renovate/renovate:39.98-full'
+    image: 'renovate/renovate:39.188-full'
     init: true
     hostname: renovate
     environment:
@@ -116,7 +116,7 @@ services:
     entrypoint: sleep
     command: infinity
   minio:
-    image: 'quay.io/minio/minio:RELEASE.2024-12-18T13-15-44Z'
+    image: 'quay.io/minio/minio:RELEASE.2025-02-28T09-55-16Z'
     hostname: minio
     environment:
       MINIO_BROWSER_REDIRECT_URL: ${MINIO_BROWSER_REDIRECT_URL:-http://localhost}
@@ -132,7 +132,7 @@ services:
       - git_cicd_net
     command: 'server --console-address ":9001"'
   mc:
-    image: 'quay.io/minio/mc:RELEASE.2024-11-21T17-21-54Z'
+    image: 'quay.io/minio/mc:RELEASE.2025-02-21T16-00-46Z'
 
 volumes:
   git_data: {}


### PR DESCRIPTION
* `gitea/gitea` from 1.23.0 to 1.23.5
* `drone/drone` from 2.25.0 to 2.26.0
* `drone/drone-runner-docker` from 1.8.3 to 1.8.4
* `renovate/renovate` from 39.98-full to 39.188-full
* `quay.io/minio/minio` from RELEASE.2024-12-18T13-15-44Z to RELEASE.2025-02-28T09-55-16Z
* `quay.io/minio/mc` from RELEASE.2024-11-21T17-21-54Z to RELEASE.2025-02-21T16-00-46Z