### PR TITLE
fix(cicd): downgrade `premoweb/chadburn` to last good version

### DIFF
--- a/gitea/docker-compose.yml
+++ b/gitea/docker-compose.yml
@@ -81,7 +81,7 @@ services:
     networks:
       - git_cicd_net
   cron:
-    image: 'premoweb/chadburn:1.9.5'
+    image: 'premoweb/chadburn@sha256:096be3c00f39db7d7d33763432456ab8bdc79f0f5da7ec20fec5ff071f3e841f'
     init: true
     hostname: cron
     volumes:

--- a/gitea/docker-compose.yml
+++ b/gitea/docker-compose.yml
@@ -81,7 +81,7 @@ services:
     networks:
       - git_cicd_net
   cron:
-    image: 'premoweb/chadburn@sha256:096be3c00f39db7d7d33763432456ab8bdc79f0f5da7ec20fec5ff071f3e841f'
+    image: 'premoweb/chadburn@1.0.7'
     init: true
     hostname: cron
     volumes:


### PR DESCRIPTION
The latest release of `premoweb/chadburn` isn't production ready.

Therefore, we downgraded to the last tagged stable version.